### PR TITLE
Change 10mm default filament load/unload length from 10mm to 160mm

### DIFF
--- a/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
@@ -180,7 +180,7 @@ page: filament
 script:
   {% set t5uid1 = printer.t5uid1 %}
   {% do set_variable("filament_extruder", t5uid1.constants.extruder_current) %}
-  {% do set_variable("filament_length", 150) %}
+  {% do set_variable("filament_length", 160) %}
 
 [t5uid1_routine __pid]
 trigger: enter_pre


### PR DESCRIPTION
10mm too short to be useful.
160mm a good default value for direct drive printers.
Stock CR6 machines are Bowden, but many users have also gone DD.

In a future release, this parameter should become modifiable in printer.cfg, in the t5uid1 section..