### PR TITLE
New at1.2.1

### DIFF
--- a/Related Changes/Overwrite these Klipper host files/Upload these configuration files to the Machine folder in Mainsail/CR6.cfg
+++ b/Related Changes/Overwrite these Klipper host files/Upload these configuration files to the Machine folder in Mainsail/CR6.cfg
@@ -66,54 +66,6 @@ enable_force_move: True
 #####################################################
 
 ######################################################################
-# BEEP (M300)
-######################################################################
-# Source File: https://github.com/Klipper3d/klipper/blob/master/config/sample-macros.cfg
-
-# [gcode_macro M300]
-# gcode:
-    # Use a default 1kHz tone if S is omitted.
-#    {% set S = params.S|default(1000)|int %}
-    # Use a 10ms duration is P is omitted.
-#    {% set P = params.P|default(100)|int %}
-#    SET_PIN PIN=BEEPER_pin VALUE=0.5 CYCLE_TIME={ 1.0/S if S > 0 else 1 }
-#    G4 P{P}
-#    SET_PIN PIN=BEEPER_pin VALUE=0
-#
-#######################$$################$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-# _CLIENT_VARIABLE
-###################################################$$$$$$$$$$$$$$$$$$$$
-# Copy/Pasted here from Mainsail.cfg
-# Used to enable the CANCEL_PRINT macro to Park the toolhead
-#
-[gcode_macro _CLIENT_VARIABLE]
-variable_use_custom_pos  : True ; use custom park coordinates for x,y [True/False] 
-variable_custom_park_x   : 230  ; custom x position; value must be within your defined min and max of X
-variable_custom_park_y   : 230   ; custom y position; value must be within your defined min and max of Y
-variable_custom_park_dz  : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position 
-variable_retract         : 1.0   ; the value to retract while PAUSE
-variable_cancel_retract  : 1.0   ; the value to retract while CANCEL_PRINT
-variable_speed_retract   : 35.0  ; retract speed in mm/s
-variable_unretract       : 1.0   ; the value to unretract while RESUME
-variable_speed_unretract : 35.0  ; unretract speed in mm/s
-variable_speed_hop       : 15.0  ; z move speed in mm/s
-variable_speed_move      : 100.0 ; move speed in mm/s
-variable_park_at_cancel  : True ; allow to move the toolhead to park while execute CANCEL_PRINT [True,False]
-## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
-variable_use_fw_retract  : True ; use fw_retraction instead of the manual version [True/False] 
-gcode:
-## After you uncomment it add your custom values
-
-## You now can use your PAUSE macro direct in your M600 here a short example:
-
-#[gcode_macro M600]
-#description: Filament change
-#gcode: PAUSE X=10 Y=10 Z_MIN=50
-
-## That will park your head front left with a minimum hight of 50mm above the bed. If your head
-## is already above 50mm it will use only the z_hop specified with dz.
-
-######################################################################
 # Filament Change at Layer/Height (M600)
 ######################################################################
 
@@ -124,6 +76,8 @@ gcode:
 # with the "RESUME" gcode.
 
 [pause_resume]
+# Uncommenting this section has enabled the commands: PAUSE, RESUME and CANCEL_PRINT
+# DO NOT, therefore, also paste-in and uncomment [gcode_macro _CLIENT_VARIABLE] from Mainsail.cfg !!
 
 [gcode_macro M600]
 gcode:
@@ -279,7 +233,7 @@ gcode:
 	G90 ;Absolute positioning
 	M84 X Y E ;Disable all steppers but Z
 	M82 ;absolute extrusion mode
-	TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=50  ##Use part cooling fan to help cool nozzle after print
+	#TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=50  ##Use part cooling fan to help cool nozzle after print
 	M106 S0 ;Turn-off part cooling 
     DGUS_PRINT_END
 

--- a/Related Changes/Overwrite these Klipper host files/Upload these configuration files to the Machine folder in Mainsail/moonraker.conf
+++ b/Related Changes/Overwrite these Klipper host files/Upload these configuration files to the Machine folder in Mainsail/moonraker.conf
@@ -25,9 +25,14 @@ cors_domains:
 [history]
 
 [update_manager]
-channel: dev
+channel:dev
 refresh_interval: 168
 enable_auto_refresh: False
+
+[update_manager client mainsail]
+type: web
+repo: mainsail-crew/mainsail
+path: ~/mainsail
 
 [update_manager mainsail-config]
 type: git_repo

--- a/Related Changes/Overwrite these Klipper host files/Upload these configuration files to the Machine folder in Mainsail/printer.cfg
+++ b/Related Changes/Overwrite these Klipper host files/Upload these configuration files to the Machine folder in Mainsail/printer.cfg
@@ -66,7 +66,7 @@ enable_pin: !PB14
 microsteps: 64
 rotation_distance: 40
 endstop_pin: PC0
-position_min: -2
+position_min: -3
 position_endstop: -2
 position_max: 235
 homing_speed: 50
@@ -86,7 +86,7 @@ enable_pin: !PB11
 microsteps: 64
 rotation_distance: 20
 endstop_pin: PC1
-position_min: 0
+position_min: -1
 position_endstop: 0
 position_max: 235
 homing_speed: 50

--- a/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
@@ -180,7 +180,7 @@ page: filament
 script:
   {% set t5uid1 = printer.t5uid1 %}
   {% do set_variable("filament_extruder", t5uid1.constants.extruder_current) %}
-  {% do set_variable("filament_length", 160) %}
+  {% do set_variable("filament_length", 150) %}
 
 [t5uid1_routine __pid]
 trigger: enter_pre

--- a/klippy/extras/t5uid1/dgus_reloaded/vars_in.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/vars_in.cfg
@@ -32,6 +32,7 @@ script:
     {% if t5uid1.is_printing %}
       {% if 'virtual_sdcard' in printer and printer.virtual_sdcard.file_position != 0 %}
         CANCEL_PRINT
+        END_PRINT
       {% else %}
         RESPOND TYPE=command MSG=action:cancel
       {% endif %}
@@ -692,6 +693,22 @@ script:
     {% do set_variable("wait_return", "boot") %}
     SAVE_CONFIG
     {% do start_routine("show_wait_screen") %}
+  {% endif %}
+run_as_gcode: true
+
+[t5uid1_var __return_tune]
+type: input
+address: 0x2031
+data_type: none
+script:
+  {% if t5uid1.is_printing and printer.pause_resume.is_paused %}
+    {% do start_routine("trigger_full_update") %}
+    {% do switch_page("print_paused") %}
+    {% do set_message("PAUSED") %}
+  {% else %}
+    {% do start_routine("trigger_full_update") %}
+    {% do switch_page("print_status") %}
+    {% do set_message("PRINTING") %}
   {% endif %}
 run_as_gcode: true
 


### PR DESCRIPTION
Fixed the Pause and Stop problems (may have been unique to some misconfiguration of the test printer).

Added END_PRINT to the stop (cancel) process, so that printer returns to a stable configuration after cancelling.
Commented-out the END_PRINT step that waits for nozzle temp = 50C, to speed up the end routine.

Removed commented-out [gcode M300] from CR6.cfg, since the modified Klipper already contains an M300 macro and leaving it in just complicates reading of the cfg file.

Edited the x&y min position values in printer.cfg. Chasing the cause of some Console error "move out of range" errors.
(TBD whether this solved those.)

Added a script to support returning from the Tune menu from either the print_status or the paused_print page.