### PR TITLE
Update README.MD with info about Klipper updates and the Klipper-DGUS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,34 @@ This repository may be very helpful for you: https://github.com/KoenVanduffel/CR
 
 ## Why Not Just Use the Desuuuu/Klipper version?
 Some of the functionality implemented in the CR6-specific UI is not present or is organized differently, in the Desuuuu companion display app.
-To enable that functionality, it was necessary to edit a few of the Desuuuu/Klipper files.
+To enable that functionality, it is necessary to edit a few of the Desuuuu/Klipper files, for which I needed to make my own (this) fork.
 
-Unfortunately, when using Moonraker Update Manager to keep all of my system and application files up to date, I could not find a way to configure the Moonraker Update Manager to stop it reverting my modified files back to the Desuuuu versions, nor could I find a way to get it to automatically keep the modified Klipper installation up to date.  I was also not willing to wait and hope for Desuuuu to implement Pull Requests against his master version, to get this CR6 project rolling.  
+## Is This Klipper Fork Using the latest Klipper3D/master version?
+No.  
+As of Jan 2023: 
+- the latest release of Klipper is 0.11.0, available 28 Nov 2022.
+- the Desuuuu fork was last updated with Klipper 0.10.0, available 29 Sept 2022.
+- this CR6Community Edition is a fork of the Desuuuu fork.
 
-The best option seemed to be to establish this CR6-specific master repository, from which Moonraker can keep DGUS-Reloaded for CR6 installations of Klipper up to date. 
+Worst-case, this solution may always be limited to exploiting [the features and capabilities of Klipper at release 0.10.0](https://github.com/Thinkersbluff/dgus-reloaded_klipper/blob/DGUS-ReloadedForCR6/docs/Releases.md).
 
+Because of the customizations in some of the klipper/src/ files, updating this fork is not as simple as using GitHub to merge this repo with the Klipper3D master branch.  If and when Desuuuu updates his fork, I will certainly update this one, but I have neither the expertise nor the time to decipher the conflicts introduced by recent upstream mods to the stm32 serial interface modules. (If there are CR6Community members who are both capable and willing to take on that challenge, please let me know in the Discussions section.  I am certainly open to reviewing PRs.)
 
-## Additional Recommended Reading
+## Is There Another Way to Re-Activate My Stock CR6 Display on Klipper, Without Getting Locked-in to Klipper 0.10.10?
+
+If being "locked-in" to Klipper v0.10.0 is not ok for you, but you still want a way to reuse your stock CR6 DWIN display, you may prefer trying [this alternative approach](https://github.com/Thinkersbluff/Klipper-dgus_CR6), which uses a separate serial interface to the display and the Moonraker API.  I only have the bandwidth to focus on this project or that one, but it is in my mind to try to develop a single DWIN_SET app that is compatible with either serial interface solution, if such a thing is possible.    
+
+## Recommended References
 To learn more about Klipper3d.org and about the DGUS-RELOADED project, you are strongly encouraged to follow these links:
 
 ### All about Klipper3D, in their own words
 [![Klipper](docs/img/klipper-logo-small.png)](https://www.klipper3d.org/)  https://www.klipper3d.org/
 
 ### The DGUS-RELOADED Klipper Project, by Desuuuu
-
  https://github.com/Desuuuu/Klipper
+ 
+ ### The Klipper-DGUS project, by SEHO85 (BUZZ-T on the CR6Community Discord)
+ This project is the "alternative approach" to which I refer, above.
+  - His GitHub project is here: https://github.com/seho85/klipper-dgus
+  - The CR6-compatible fork of his DWIN_SET UI is here: https://github.com/Thinkersbluff/Klipper-dgus_CR6
+  


### PR DESCRIPTION
… alternative to this project

In response to a query about updating this fork to the latest Klipper version (0.11.0), I have updated this README to explain:
- This fork is locked-in to whatever version of Klipper the upstream fork is using
- If the upstream fork is updated, then I will update this one, too, but I can not make promises about what (or when) the upstream dev will/will-not decide to do
- There is a second option for interfacing the stock CR6 display to Klipper, which is "Klipper-DGUS".  I have refactored that (Vyper) DWIN_SET for CR6 and I now link to his project and mine in this README

Signed-off-by: Thinkersbluff <36551518+Thinkersbluff@users.noreply.github.com>