### PR TITLE
Fixes Issue#Issue#13 for DWIN_SET v0.3.3

### DIFF
--- a/klippy/extras/t5uid1/dgus_reloaded/vars_out.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/vars_out.cfg
@@ -28,11 +28,13 @@ script: { "{:<26s}".format(get_variable("line4", "")|trim|truncate(24, True)) }
 
 [t5uid1_var message]
 type: output
-address: 0x3000
+# NB:  1. Must start writing scrolling text content at VP+3 bytes
+#      2. Have set this field to Static, anyway, on Priht Status page, (i.e. does not scroll)
+#         because is bothersome to see TWO scrolling fields race across the screen...
+address: 0x3003
 data_type: str
-data_len: 30
-# Right-justify text, read first 32 characters of message variable, 
-script: { "%30s"|format(get_variable("message", "")|trim|truncate(26, True)) }
+data_len: 26 
+script: { "{:<26s}".format(get_variable("message", "")|trim|truncate(26, True)) }
 
 [t5uid1_var status_position_z]
 type: output
@@ -449,19 +451,24 @@ script:
 
 [t5uid1_var file_name]
 type: output
-address: 0x31be
+# NB: 1. Per DWIN App Dev Guide - Must write text 3 bytes AFTER actual variable pointer!!
+#     2. Although DWIN_SET field is left-justified, atill don't get first couple of letters unless Right justify in the format instruction??
+#     3. Max # of characters that fit on 272-pixel screen = 26
+#     4. Max specifiable field length = 32 characters, forced by T5UID1 messaging code, somewhere...
+#        Consider how to split longer filenames into chunks & display on a rotating basis??
+address: 0x31c1
 data_type: str
-data_len: 30
+data_len: 32
 script:
   {% if printer.print_stats.filename %}
-    {"{:>30s}".format(printer.print_stats.filename|trim|truncate(24, True))}
+    {"{:>32s}".format(printer.print_stats.filename|trim)}
   {% else %}
     {"No name passed by slicer"}    
   {% endif %}
 
 [t5uid1_var tot_duration]
 type: output
-address: 0x31dd
+address: 0x31e0
 data_type: str
 data_len: 15
 script:
@@ -470,18 +477,6 @@ script:
   {% else %}
     {"Not working"}    
   {% endif %}
-
-[t5uid1_var filament_used]
-type: output
-address: 0x31e7
-data_type: str
-data_len: 8
-script:
-  {% if printer.print_stats.filament_used %}
-    {"{:>8s}".format(printer.print_stats.filament_used)|trim}
-  {% else %}
-    {" Not Working"}    
-  {% endif %} 
 
 [t5uid1_var fan_speed]
 type: output


### PR DESCRIPTION
Fixes Issue#13: v0.3.3 - The contents of scrolling Text fields are not aligning left, correctly (the first few characters are missing)

Per comments added to the code, the scrolling text widgets used in DWIN_SET do not work correctly when the text contents are pasted into any of the first 3 bytes.  Pays to read the f_ing manual, once in a while...