### PR TITLE
Restore last line of is_busy() routine in t5uid1.py to original logic

### DIFF
--- a/klippy/extras/t5uid1/t5uid1.py
+++ b/klippy/extras/t5uid1/t5uid1.py
@@ -925,8 +925,8 @@ class T5UID1:
                 or idle_time < 1.0
                 or self.gcode.get_mutex().test()):
             return True
-        return False
-
+        # If there is a probe, and if the probe is currently performing multiple probes, return True, else return False
+        return (self.probe is not None and self.probe.probe_session.homing_helper.multi_probe_pending)
     def cmd_DGUS_ABORT_PAGE_SWITCH(self, gcmd):
         pass
 


### PR DESCRIPTION
Rev 1.3.2 replaced the "If probe is not None..." logic test with a the value "False", to provide a quick fix to the bugs introduced by a Klipper mod in June 2024, while I researched the correct "fix". This mod now implements the "correct" fix, by updating the address of the multi_probe_pending property, which changed when probe.py was refactored.