### PR TITLE
Commented out inline comment to resolve config syntax error. Fixed reference to homing_helper which causes crash (it was moved in klipper).

### DIFF
--- a/Related Changes/BTT SKR CR6 Only/Custom Klipper host files/DGUS-Reloaded.cfg
+++ b/Related Changes/BTT SKR CR6 Only/Custom Klipper host files/DGUS-Reloaded.cfg
@@ -28,7 +28,7 @@ z_max: 250
 #   Same as x_max for the Z axis.
 
 # NOTE: As of v1.3.6 of the DGUS-Reloaded Klipper Component, Material Presets are stored in presets.cfg and can be managed via the SetUp menu or by editing the presets.cfg text file.
-The original Material temperature preset values are still also defined in dgus_reloaded/__init__.py, as follows:
+# The original Material temperature preset values are still also defined in dgus_reloaded/__init__.py, as follows:
 #    'temp_pla': {
 #        'hotend': 210,
 #        'bed': 60

--- a/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For 4.5.2 MB/DGUS-Reloaded.cfg
+++ b/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For 4.5.2 MB/DGUS-Reloaded.cfg
@@ -28,7 +28,7 @@ z_max: 250
 #   Same as x_max for the Z axis.
 
 # NOTE: As of v1.3.6 of the DGUS-Reloaded Klipper Component, Material Presets are stored in presets.cfg and can be managed via the SetUp menu or by editing the presets.cfg text file.
-The original Material temperature preset values are still also defined in dgus_reloaded/__init__.py, as follows:
+# The original Material temperature preset values are still also defined in dgus_reloaded/__init__.py, as follows:
 #    'temp_pla': {
 #        'hotend': 210,
 #        'bed': 60

--- a/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For ERA 1.1.0.3 and 4.5.3 MB/DGUS-Reloaded.cfg
+++ b/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For ERA 1.1.0.3 and 4.5.3 MB/DGUS-Reloaded.cfg
@@ -28,7 +28,7 @@ z_max: 250
 #   Same as x_max for the Z axis.
 
 # NOTE: As of v1.3.6 of the DGUS-Reloaded Klipper Component, Material Presets are stored in presets.cfg and can be managed via the SetUp menu or by editing the presets.cfg text file.
-The original Material temperature preset values are still also defined in dgus_reloaded/__init__.py, as follows:
+# The original Material temperature preset values are still also defined in dgus_reloaded/__init__.py, as follows:
 #    'temp_pla': {
 #        'hotend': 210,
 #        'bed': 60

--- a/klippy/extras/t5uid1/t5uid1.py
+++ b/klippy/extras/t5uid1/t5uid1.py
@@ -1120,7 +1120,7 @@ class T5UID1:
             return True
         # If there is a probe, and if the probe is currently performing multiple probes,
         # return True, else return False
-        return (self.probe is not None and self.probe.probe_session.homing_helper.multi_probe_pending)
+        return (self.probe is not None and self.probe.homing_helper.multi_probe_pending)
 
     def cmd_DGUS_ABORT_PAGE_SWITCH(self, gcmd):
         """define abort_page_switch as a no-op function"""


### PR DESCRIPTION
Commented out inline comment to resolve config syntax error.
Fixed reference to homing_helper which causes crash (it was moved in klipper).