### PR TITLE
Modifies PID to pre-select the filament type1 preset temps by default

### DIFF
--- a/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
@@ -299,8 +299,14 @@ trigger: enter_pre
 page: pid
 script:
   {% set t5uid1 = printer.t5uid1 %}
+
+  {% set default_hotend_pid_temp = get_preset_values('filament_type_1_default_nozzle_temp', t5uid1.constants.temp_pla.hotend) %}
+  {% set default_bed_pid_temp = get_preset_values('filament_type_1_default_bed_temp', t5uid1.constants.temp_pla.bed) %}
+  {% do set_variable("default_hotend_pid_temp", default_hotend_pid_temp) %}
+  {% do set_variable("default_bed_pid_temp", default_bed_pid_temp) %}
+
   {% do set_variable("pid_heater", t5uid1.constants.heater_h0) %}
-  {% do set_variable("pid_temp", t5uid1.constants.temp_pla.hotend) %}
+  {% do set_variable("pid_temp", default_hotend_pid_temp) %}
 
 [t5uid1_routine __info]
 trigger: enter_pre

--- a/klippy/extras/t5uid1/dgus_reloaded/vars_in.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/vars_in.cfg
@@ -827,14 +827,16 @@ script:
   #M300 P10
   {% set t5uid1 = printer.t5uid1 %}
   {% if data == t5uid1.constants.heater_bed %}
-    {% do set_variable("pid_temp", t5uid1.constants.temp_pla.bed) %}
+    {% set default_bed_pid_temp = get_variable("default_bed_pid_temp", 0) %} 
+    {% do set_variable("pid_temp", default_bed_pid_temp) %}
     {% do set_variable("pid_heater", data) %}
   {% elif data == t5uid1.constants.heater_h0 %}
-    {% do set_variable("pid_temp", t5uid1.constants.temp_pla.hotend) %}
+    {% set default_hotend_pid_temp = get_variable("default_hotend_pid_temp", 0) %} 
+    {% do set_variable("pid_temp", default_hotend_pid_temp) %}
     {% do set_variable("pid_heater", data) %}
-  {% elif data == t5uid1.constants.heater_h1 %}
-    {% do set_variable("pid_temp", t5uid1.constants.temp_pla.hotend) %}
-    {% do set_variable("pid_heater", data) %}
+  #{% elif data == t5uid1.constants.heater_h1 %}
+    #{% do set_variable("pid_temp", t5uid1.constants.temp_pla.hotend) %}
+    #{% do set_variable("pid_heater", data) %}
   {% endif %}
   {% do start_routine("trigger_full_update") %}
 run_as_gcode: false


### PR DESCRIPTION
Used to select the init.py constants.  Now will use the preset values for filament type1. If no default temps are specified in presets.cfg, the firmware uses the init_py values instead.