### PR TITLE
Fixes Issue#77

### DIFF
--- a/Related Changes/BTT SKR CR6 Only/Custom Klipper host files/CR6.cfg
+++ b/Related Changes/BTT SKR CR6 Only/Custom Klipper host files/CR6.cfg
@@ -346,6 +346,7 @@ gcode:
   G1 Z10 F500 ;Raise Z 
   G90 ; Use absolute positioning
   G1 X0 Y225 F5000 ;Present print
+  DGUS_PRINT_END ; # Causes DGUS-Reloaded to switch to the "Print Finished" screen and resets Flow Rate and Feed Rate to 100%
   {% if printer.extruder.can_extrude %}
     {% set svv = printer.save_variables.variables %}
     {% if svv.unload_filament_after_print==1 %}
@@ -362,7 +363,6 @@ gcode:
   M106 S255 ;full fan, to accelerate cooling
   TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=150 ; Wait for nozzle to cool below 150C
   STOP_COUNTDOWN_TIMER
-  DGUS_PRINT_END ; # Causes DGUS-Reloaded to switch to the "Print Finished" screen
   M106 S0 ;Turn-off part cooling fan
   M84 X Y E ;Disable all steppers but Z
   M300

--- a/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For 4.5.2 MB/CR6.cfg
+++ b/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For 4.5.2 MB/CR6.cfg
@@ -346,6 +346,7 @@ gcode:
   G1 Z10 F500 ;Raise Z 
   G90 ; Use absolute positioning
   G1 X0 Y225 F5000 ;Present print
+  DGUS_PRINT_END ; # Causes DGUS-Reloaded to switch to the "Print Finished" screen and resets Flow Rate and Feed Rate to 100%
   {% if printer.extruder.can_extrude %}
     {% set svv = printer.save_variables.variables %}
     {% if svv.unload_filament_after_print==1 %}
@@ -362,7 +363,6 @@ gcode:
   M106 S255 ;full fan, to accelerate cooling
   TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=150 ; Wait for nozzle to cool below 150C
   STOP_COUNTDOWN_TIMER
-  DGUS_PRINT_END ; # Causes DGUS-Reloaded to switch to the "Print Finished" screen
   M106 S0 ;Turn-off part cooling fan
   M84 X Y E ;Disable all steppers but Z
   M300

--- a/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For ERA 1.1.0.3 and 4.5.3 MB/CR6.cfg
+++ b/Related Changes/Creality CR6 Mobo/Custom Klipper host files/For ERA 1.1.0.3 and 4.5.3 MB/CR6.cfg
@@ -346,6 +346,7 @@ gcode:
   G1 Z10 F500 ;Raise Z 
   G90 ; Use absolute positioning
   G1 X0 Y225 F5000 ;Present print
+  DGUS_PRINT_END ; # Causes DGUS-Reloaded to switch to the "Print Finished" screen and resets Flow Rate and Feed Rate to 100%
   {% if printer.extruder.can_extrude %}
     {% set svv = printer.save_variables.variables %}
     {% if svv.unload_filament_after_print==1 %}
@@ -362,7 +363,6 @@ gcode:
   M106 S255 ;full fan, to accelerate cooling
   TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=150 ; Wait for nozzle to cool below 150C
   STOP_COUNTDOWN_TIMER
-  DGUS_PRINT_END ; # Causes DGUS-Reloaded to switch to the "Print Finished" screen
   M106 S0 ;Turn-off part cooling fan
   M84 X Y E ;Disable all steppers but Z
   M300


### PR DESCRIPTION
Moves DGUS_PRINT_END command ahead of the test for Auto_Unload_after_print in [gcode_macro END_PRINT] to fix Issue#77

Realized that the flow rate parameter was not being reset to 100% before performing the auto unload.