### PR TITLE
Show_Wait_Screen when user commands a restart

### DIFF
--- a/klippy/extras/t5uid1/dgus_reloaded/vars_in.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/vars_in.cfg
@@ -1087,8 +1087,15 @@ address: 0x203F
 data_type: uint16
 script:
   #M300 P10
+  {% do set_variable("line1", "Updating Extruder") %}
+  {% do set_variable("line2", "Rotation Distance") %}
+  {% do set_variable("line3", "in printer.cfg") %}
+  {% do set_variable("line4", "and Restarting Firmware...") %}
+  {% do start_routine("show_wait_screen") %}
+
   {% set new_value = get_variable("new_rotation_distance") + 0.001 %}
   {% do replace_printer_cfg_value("extruder","rotation_distance",new_value) %}
+
   FIRMWARE_RESTART
 run_as_gcode: true
    
@@ -1114,6 +1121,11 @@ address: 0x2FFD
 data_type: uint16
 script:
   #M300 P10
+  {% do set_variable("line1", "") %}
+  {% do set_variable("line2", "Reloading config") %}
+  {% do set_variable("line3", "and") %}
+  {% do set_variable("line4", "Restarting Firmware...") %}
+  {% do start_routine("show_wait_screen") %}
   RESTART
 run_as_gcode: true
 
@@ -1123,6 +1135,11 @@ address: 0x2FFE
 data_type: uint16
 script:
   #M300 P10
+  {% do set_variable("line1", "Resetting Error State,") %}
+  {% do set_variable("line2", "Reloading config") %}
+  {% do set_variable("line3", "and") %}
+  {% do set_variable("line4", "Restarting Firmware...") %}
+  {% do start_routine("show_wait_screen") %}
   FIRMWARE_RESTART
 run_as_gcode: true
 


### PR DESCRIPTION
Pressing buttons like FIRMWARE_RESTART can take so long to act that it leaves the user wondering whether or not the command is being implemented.  

This change uses the Wait screen to confirm to the user that a restart is indeed in process.