### PR TITLE
Add "If is_busy(), abort_page_switch" logic to all enter_pre routine …

### DIFF
--- a/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
+++ b/klippy/extras/t5uid1/dgus_reloaded/routines.cfg
@@ -246,29 +246,39 @@ trigger: enter_pre
 page: print_menu
 interval: 2
 script: 
-  {% do capture_gcode_files('~/printer_data/gcodes') %}
-  {% do set_variable("tapped_index", 0) %}
-  {% do set_variable("scroll_index", 0) %}
-  {% do set_variable("visible_start", 0) %}
+  {% if is_busy() %}
+    {% do set_message("Busy") %}
+    { abort_page_switch() }
+  {% else %}
+    {% do capture_gcode_files('~/printer_data/gcodes') %}
+    {% do set_variable("tapped_index", 0) %}
+    {% do set_variable("scroll_index", 0) %}
+    {% do set_variable("visible_start", 0) %}
+  {% endif %}
 
 [t5uid1_routine __build_macros_menu]
 trigger: enter_pre
 page: macros
 interval: 1
 script:
-  {% set macro_menu_section = get_variable("macro_menu_section") %}
-  {% set macro_menu_names = capture_macros_list(macro_menu_section) or [] %}
-  {% set max_visible_lines = 9 %}
-  {% do set_variable("macro_menu_names", macro_menu_names) %}   
-  {% do set_variable("macro_menu_index", 0) %}
-  {% do set_variable("highlighted_index", 0) %}
-  {% do set_variable("visible_start", 0) %} 
-  {% do set_variable("max_visible_lines", max_visible_lines) %}
-  {% do set_variable("page_number", 1) %}
-  {% set number_of_pages = (macro_menu_names|length + max_visible_lines - 1) // max_visible_lines %}
-  {% do set_variable("number_of_pages", number_of_pages) %}
-  M117 Page { get_variable("page_number") } of { number_of_pages }
-  {% do start_routine("trigger_full_update") %} # Refresh displayed variables on page
+  {% if is_busy() %}
+    {% do set_message("Busy") %}
+    { abort_page_switch() }
+  {% else %}
+    {% set macro_menu_section = get_variable("macro_menu_section") %}
+    {% set macro_menu_names = capture_macros_list(macro_menu_section) or [] %}
+    {% set max_visible_lines = 9 %}
+    {% do set_variable("macro_menu_names", macro_menu_names) %}   
+    {% do set_variable("macro_menu_index", 0) %}
+    {% do set_variable("highlighted_index", 0) %}
+    {% do set_variable("visible_start", 0) %} 
+    {% do set_variable("max_visible_lines", max_visible_lines) %}
+    {% do set_variable("page_number", 1) %}
+    {% set number_of_pages = (macro_menu_names|length + max_visible_lines - 1) // max_visible_lines %}
+    {% do set_variable("number_of_pages", number_of_pages) %}
+    M117 Page { get_variable("page_number") } of { number_of_pages }
+    {% do start_routine("trigger_full_update") %} # Refresh displayed variables on page
+  {% endif %}
 run_as_gcode: true
 
 [t5uid1_routine __leave_macros_menu]
@@ -282,9 +292,14 @@ script:
 trigger: enter_pre
 page: filament
 script:
-  {% set t5uid1 = printer.t5uid1 %}
-  {% do set_variable("filament_extruder", t5uid1.constants.extruder_current) %}
-  {% do set_variable("filament_length", 150) %}
+  {% if is_busy() %}
+    {% do set_message("Busy") %}
+    { abort_page_switch() }
+  {% else %}
+    {% set t5uid1 = printer.t5uid1 %}
+    {% do set_variable("filament_extruder", t5uid1.constants.extruder_current) %}
+    {% do set_variable("filament_length", 150) %}
+  {% endif %}
 
 [t5uid1_routine __filament_paused]
 trigger: enter_pre
@@ -298,15 +313,20 @@ script:
 trigger: enter_pre
 page: pid
 script:
-  {% set t5uid1 = printer.t5uid1 %}
+  {% if is_busy() %}
+    {% do set_message("Busy") %}
+    { abort_page_switch() }
+  {% else %}
+    {% set t5uid1 = printer.t5uid1 %}
 
-  {% set default_hotend_pid_temp = get_preset_values('filament_type_1_default_nozzle_temp', t5uid1.constants.temp_pla.hotend) %}
-  {% set default_bed_pid_temp = get_preset_values('filament_type_1_default_bed_temp', t5uid1.constants.temp_pla.bed) %}
-  {% do set_variable("default_hotend_pid_temp", default_hotend_pid_temp) %}
-  {% do set_variable("default_bed_pid_temp", default_bed_pid_temp) %}
+    {% set default_hotend_pid_temp = get_preset_values('filament_type_1_default_nozzle_temp', t5uid1.constants.temp_pla.hotend) %}
+    {% set default_bed_pid_temp = get_preset_values('filament_type_1_default_bed_temp', t5uid1.constants.temp_pla.bed) %}
+    {% do set_variable("default_hotend_pid_temp", default_hotend_pid_temp) %}
+    {% do set_variable("default_bed_pid_temp", default_bed_pid_temp) %}
 
-  {% do set_variable("pid_heater", t5uid1.constants.heater_h0) %}
-  {% do set_variable("pid_temp", default_hotend_pid_temp) %}
+    {% do set_variable("pid_heater", t5uid1.constants.heater_h0) %}
+    {% do set_variable("pid_temp", default_hotend_pid_temp) %}
+  [% endif %]
 
 [t5uid1_routine __info]
 trigger: enter_pre


### PR DESCRIPTION
…scripts

Saw one instance of Load Profile function not working. Suspect was due to selecting Leveling Automatic page while a print was still finishing. Looked like the enter_pre routine could not run while the printer was busy...

Have added this abort_page_switch logic to:
- Print_Menu select button
- all Macros Menu select buttons
- Change FIlament menu select button
- Select PID menu button